### PR TITLE
add ELF 32-bit support

### DIFF
--- a/qsym/afl.py
+++ b/qsym/afl.py
@@ -52,13 +52,14 @@ def mkdir(dirp):
         os.makedirs(dirp)
 
 def check_so_file():
-    if not os.path.exists(SO):
-        # Maybe updating now.. please wait
-        logger.debug("Cannot find pintool. Maybe updating?")
-        time.sleep(3 * 60)
+    for SO_file in SO.values():
+        if not os.path.exists(SO_file):
+            # Maybe updating now.. please wait
+            logger.debug("Cannot find pintool. Maybe updating?")
+            time.sleep(3 * 60)
 
-    if not os.path.exists(SO):
-        FATAL("Cannot find SO file!")
+        if not os.path.exists(SO_file):
+            FATAL("Cannot find SO file!")
 
 def get_afl_cmd(fuzzer_stats):
     with open(fuzzer_stats) as f:

--- a/qsym/conf.py
+++ b/qsym/conf.py
@@ -18,5 +18,6 @@ def find_pin():
 
 ROOT = os.path.realpath(os.path.dirname(__file__))
 PINTOOL_DIR = os.path.join(ROOT, "pintool")
-SO = os.path.join(PINTOOL_DIR, "obj-intel64/libqsym.so")
+SO = {"intel64": os.path.join(PINTOOL_DIR, "obj-intel64/libqsym.so")}
+SO["ia32"] = os.path.join(PINTOOL_DIR, "obj-ia32/libqsym.so")
 PIN = find_pin()

--- a/qsym/conf.py
+++ b/qsym/conf.py
@@ -18,6 +18,8 @@ def find_pin():
 
 ROOT = os.path.realpath(os.path.dirname(__file__))
 PINTOOL_DIR = os.path.join(ROOT, "pintool")
-SO = {"intel64": os.path.join(PINTOOL_DIR, "obj-intel64/libqsym.so")}
-SO["ia32"] = os.path.join(PINTOOL_DIR, "obj-ia32/libqsym.so")
+SO = {
+    "intel64": os.path.join(PINTOOL_DIR, "obj-intel64/libqsym.so"),
+    "ia32": os.path.join(PINTOOL_DIR, "obj-ia32/libqsym.so")
+}
 PIN = find_pin()

--- a/qsym/executor.py
+++ b/qsym/executor.py
@@ -83,8 +83,11 @@ class Executor(object):
         cmd += ["-ifeellucky"]
 
         # Check if target is 32bit ELF
-        if self.check_elf32(): cmd += ["-t", SO["ia32"]]
-        else: cmd += ["-t", SO["intel64"]]
+        if self.check_elf32():
+            cmd += ["-t", SO["ia32"]]
+        else:
+            cmd += ["-t", SO["intel64"]]
+            
         # Add log file
         cmd += ["-logfile", self.log_file]
         cmd += ["-i", self.input_file] + self.source_opts

--- a/qsym/executor.py
+++ b/qsym/executor.py
@@ -65,6 +65,14 @@ class Executor(object):
     def log_file(self):
         return os.path.join(self.testcase_dir, "pin.log")
 
+    def check_elf32(self):
+        # assume cmd[0] is always the target binary (?)
+        if os.path.exists(self.cmd[0]):
+            with open(self.cmd[0]) as f:
+               d = f.read(5)
+               return len(d) > 4 and d[4] == chr(01)
+        return false
+
     def gen_cmd(self, timeout):
         cmd = []
         if timeout:
@@ -74,7 +82,9 @@ class Executor(object):
         # Hack for 16.04
         cmd += ["-ifeellucky"]
 
-        cmd += ["-t", SO]
+        # Check if target is 32bit ELF
+        if self.check_elf32(): cmd += ["-t", SO["ia32"]]
+        else: cmd += ["-t", SO["intel64"]]
         # Add log file
         cmd += ["-logfile", self.log_file]
         cmd += ["-i", self.input_file] + self.source_opts

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ from distutils.command.build import build as DistutilsBuild
 def build_pintool():
     if subprocess.call(["make", "-C", "qsym/pintool", "-j", str(mp.cpu_count())]) != 0:
         raise ValueError("Unable to build pintool")
-
+    my_env = os.environ.copy()
+    my_env["TARGET"] = "ia32"
+    if subprocess.call(["make", "-C", "qsym/pintool", "-j", str(mp.cpu_count())],env=my_env) != 0:
+        raise ValueError("Unable to build pintool")
     if int(open("/proc/sys/kernel/yama/ptrace_scope").read()) != 0:
         raise ValueError("Please disable yama/ptrace_scope:\n" \
                        + "echo 0 > /proc/sys/kernel/yama/ptrace_scope")
@@ -42,7 +45,7 @@ setup(name='qsym',
       packages=packages,
       include_package_data=True,
       package_data
-        = {"qsym": ["pintool/obj-intel64/libqsym.so"]},
+        = {"qsym": ["pintool/obj-intel64/libqsym.so","pintool/obj-ia32/libqsym.so"]},
       install_requires=[
           'termcolor',          # for qsym/utils.py
           'pyinotify',          # for qsym/afl.py (XXX. doesn't seem to be using?)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def build_pintool():
         raise ValueError("Unable to build pintool")
     my_env = os.environ.copy()
     my_env["TARGET"] = "ia32"
-    if subprocess.call(["make", "-C", "qsym/pintool", "-j", str(mp.cpu_count())],env=my_env) != 0:
+    if subprocess.call(["make", "-C", "qsym/pintool", "-j", str(mp.cpu_count())], env=my_env) != 0:
         raise ValueError("Unable to build pintool")
     if int(open("/proc/sys/kernel/yama/ptrace_scope").read()) != 0:
         raise ValueError("Please disable yama/ptrace_scope:\n" \

--- a/setup.sh
+++ b/setup.sh
@@ -2,8 +2,7 @@
 
 # check ptrace_scope for PIN
 if ! grep -qF "0" /proc/sys/kernel/yama/ptrace_scope; then
-  echo "Please run 'echo 0|sudo tee /proc/sys/kernel/yama/ptrace_scope'"
-  exit -1
+  echo 0|sudo tee /proc/sys/kernel/yama/ptrace_scope
 fi
 
 git submodule init
@@ -18,9 +17,15 @@ sudo apt-get install -y libc6 libstdc++6 linux-libc-dev gcc-multilib \
 # install z3
 pushd third_party/z3
 ./configure
-cd build
+pushd build
 make -j$(nproc)
 sudo make install
+popd
+rm -rf build
+./configure --x86
+cd build
+make -j$(nproc)
+sudo cp libz3.so /usr/lib32/
 popd
 
 # build test directories

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,8 @@
 
 # check ptrace_scope for PIN
 if ! grep -qF "0" /proc/sys/kernel/yama/ptrace_scope; then
-  echo 0|sudo tee /proc/sys/kernel/yama/ptrace_scope
+  echo "Please run 'echo 0|sudo tee /proc/sys/kernel/yama/ptrace_scope'"
+  exit -1
 fi
 
 git submodule init


### PR DESCRIPTION
Adding support for ELF 32-bit target binaries:
- build 32-bit z3 library (copied to `/usr/lib32/libz.so`)
- build 32-bit pintool (`pintool/obj-ia32/libqsym.so`)
- simple check in ELF header for 32/64 bit (byte 5)
- testing on [CI](https://travis-ci.com/wideglide/qsym/builds): 
    - Ubuntu 14.04 passes all but one check (unrelated to changes)
    - Ubuntu 16.04 passes all checks

An alternative option would be to add a command line parameter to `run_qsym_afl.py`, but this works cleanly in some simple tests.