### PR TITLE
Remove testcase_dir if it is empty

### DIFF
--- a/qsym/afl.py
+++ b/qsym/afl.py
@@ -387,6 +387,12 @@ class AFLExecutor(object):
         if os.path.exists(q.log_file):
             os.unlink(q.log_file)
 
+        # Remove testcase_dir if it`s empty
+        try:
+            os.rmdir(q.testcase_directory)
+        except Exception:
+            pass
+
         logger.debug("Generate %d testcases" % num_testcase)
         logger.debug("%d testcases are new" % (self.state.index - old_idx))
 

--- a/qsym/executor.py
+++ b/qsym/executor.py
@@ -65,6 +65,10 @@ class Executor(object):
     def log_file(self):
         return os.path.join(self.testcase_dir, "pin.log")
 
+    @property
+    def testcase_directory(self):
+        return self.testcase_dir
+        
     def check_elf32(self):
         # assume cmd[0] is always the target binary (?)
         if os.path.exists(self.cmd[0]):


### PR DESCRIPTION
too many directories exist, leads to system or software stuck.

test if fine
```shell
# ls -ahl
total 16K
drwx------ 3 root root 4.0K Aug  6 11:16 .
drwxrwxrwt 5 root root 4.0K Aug  6 11:13 ..
lrwxrwxrwx 1 root root   26 Aug  6 11:16 qsym-last -> /tmp/tmpTmBNzX/qsym-out-12
drwxr-xr-x 2 root root 4.0K Aug  6 11:16 qsym-out-12
-rw-r--r-- 1 root root    2 Aug  6 11:16 status
```