### PR TITLE
Remove invalid brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ our [vagrant](vagrant) directory.
 #   QSYM_CMDLINE: command line for a testing program for QSYM (Non-instrumented)
 
 # run AFL master
-$ $(AFL_ROOT)/afl-fuzz -M afl-master -i $(INPUT) -o $(OUTPUT) -- $(AFL_CMDLINE)
+$ $AFL_ROOT/afl-fuzz -M afl-master -i $INPUT -o $OUTPUT -- $AFL_CMDLINE
 # run AFL slave
-$ $(AFL_ROOT)/afl-fuzz -S afl-slave -i $(INPUT) -o $(OUTPUT) -- $(AFL_CMDLINE)
+$ $AFL_ROOT/afl-fuzz -S afl-slave -i $INPUT -o $OUTPUT -- $AFL_CMDLINE
 # run QSYM
-$ bin/run_qsym_afl.py -a afl-slave -o $(OUTPUT) -n qsym -- $(QSYM_CMDLINE)
+$ bin/run_qsym_afl.py -a afl-slave -o $OUTPUT -n qsym -- $QSYM_CMDLINE
 ~~~~
 
 ## Run for testing


### PR DESCRIPTION
Environment variables are not executable commands, we shouldn't put brackets around them. For example, `$(AFL_ROOT)` means to execute it but no to get the saved value. This will always raise an error.