### PR TITLE
fix z3 issue completely

### DIFF
--- a/qsym/pintool/Makefile
+++ b/qsym/pintool/Makefile
@@ -22,7 +22,7 @@ endif
 include $(CONFIG_ROOT)/makefile.config
 include makefile.rules
 include $(TOOLS_ROOT)/Config/makefile.default.rules
-TOOL_CXXFLAGS += -I$(ROOT)/third_party/z3/include
+TOOL_CXXFLAGS += -I/usr/local/qsym/include
 
 ##############################################################
 #

--- a/qsym/pintool/makefile.rules
+++ b/qsym/pintool/makefile.rules
@@ -66,6 +66,10 @@ endif
 
 TOOL_CXXFLAGS += -I$(CURDIR)
 TOOL_CXXFLAGS += -g -Wno-error=unused-function -std=c++11 -DCONFIG_CONTEXT_SENSITIVE
+
+TOOL_LPATHS += -Wl,-rpath=/usr/local/qsym/lib -L/usr/local/qsym/lib
+TOOL_LPATHS += -Wl,-rpath=/usr/local/qsym32/lib -L/usr/local/qsym32/lib
+
 TOOL_LIBS += -lz3
 
 ##############################################################

--- a/setup.sh
+++ b/setup.sh
@@ -18,16 +18,16 @@ sudo apt-get install -y libc6 libstdc++6 linux-libc-dev gcc-multilib \
 # install z3
 pushd third_party/z3
 rm -rf build
-./configure
+./configure --prefix=/usr/local/qsym
 pushd build
 make -j$(nproc)
 sudo make install
 popd
 rm -rf build
-./configure --x86
+./configure --x86 --prefix=/usr/local/qsym32
 cd build
 make -j$(nproc)
-sudo cp libz3.so /usr/lib32/
+sudo make install
 popd
 
 # build test directories


### PR DESCRIPTION
Hi, I found the root cause of the Z3 issue.
I observe that QSYM is broken after installing some LLVM things.
The reason is that some of the LLVM packages will depend on libz3-dev, which will also provide `libz3.so`. 
Therefore, `libqsym.so` will load an incompatible Z3.
Solution is simple, install Z3 to a custom path, and change rpath to make loader load our Z3.

BTW, `$(ROOT)/third_party/z3/include` does not exist, so I change it.