### PR TITLE
Install pip with get-pip.py instead of apt-get

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,14 @@ git submodule update
 # install system deps
 sudo apt-get update
 sudo apt-get install -y libc6 libstdc++6 linux-libc-dev gcc-multilib \
-  llvm-dev g++ g++-multilib python python-pip \
+  llvm-dev g++ g++-multilib python \
   lsb-release
+
+# install pip
+sudo apt-get install wget
+wget https://bootstrap.pypa.io/get-pip.py
+python get-pip.py
+rm -rf ./get-pip.py
 
 # install z3
 pushd third_party/z3


### PR DESCRIPTION
We failed to build the docker since the pip version may be too old when installed with apt-get (e.g., 8.1, in ubuntu 16.04).

To fix this issue, we modify the ``setup.sh`` where we install pip with ``https://bootstrap.pypa.io/get-pip.py`` instead of ``apt-get install python-pip``. This works well for me.